### PR TITLE
corrige acesso em servidor que usa porta diferente de 80

### DIFF
--- a/exemplos/NFe/gui-teste.php
+++ b/exemplos/NFe/gui-teste.php
@@ -24,7 +24,7 @@
 				$url = $_SERVER['REQUEST_URI'];
 				$i = 0;
 				for($i=strlen($url);substr($url, $i,1) != '/';$i--);
-				$url = $_SERVER['SERVER_NAME'] . substr($url, 0, $i);
+				$url = $_SERVER['HTTP_HOST'] . substr($url, 0, $i);
 			?>
 
 			//$('#btnConverterTXT').hide();


### PR DESCRIPTION
$_SERVER['HTTP_HOST'] == 'localhost:8080'
$_SERVER['SERVER_NAME'] == 'localhost'
O http_host inclui a porta em que o servidor roda. Util em servidores de teste que feralmente não são na porta 80.